### PR TITLE
docs: add starter templates

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -52,6 +52,13 @@ Quick navigation to all docs. Read only what you need, when you need it.
 **`[platform]-release.md`** - Publishing
 
 
+## Templates
+
+**[templates/](templates/)** - Starter files for new projects
+- `PLATFORM-DEVELOPMENT.template.md` - Platform development guide structure
+- `changelog.template.md` - Keep a Changelog format
+
+
 ## Project Management
 
 **[project/](project/README.md)** - Working area (cleaned after iteration)

--- a/docs/templates/PLATFORM-DEVELOPMENT.template.md
+++ b/docs/templates/PLATFORM-DEVELOPMENT.template.md
@@ -1,0 +1,83 @@
+# [Platform] Development Guide
+
+Platform-specific development setup, commands, and patterns.
+
+
+## Tech Stack
+
+- **Platform:** [e.g., Android (Kotlin), iOS (Swift), Web (TypeScript)]
+- **UI:** [e.g., Jetpack Compose, SwiftUI, React]
+- **Architecture:** [e.g., MVVM, MVC, Clean Architecture]
+- **Build System:** [e.g., Gradle, Xcode, npm]
+- **Testing:** [e.g., JUnit, XCTest, Jest]
+
+
+## Architecture
+
+### Layer Separation
+
+```
+UI -> Presentation -> Domain -> Data -> Core
+```
+
+**Dependencies flow inward** - outer layers depend on inner layers.
+
+
+## Build Commands
+
+```bash
+# Build
+[build command]
+
+# Install
+[install command]
+```
+
+**Running tests?** See `[platform]-testing.md`
+
+
+## Code Patterns
+
+### Naming Conventions
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Screen | `[Feature]Screen` | `SettingsScreen` |
+| ViewModel | `[Feature]ViewModel` | `SettingsViewModel` |
+| Repository | `[Domain]Repository` | `UserRepository` |
+
+
+## File Organization
+
+```
+src/
+├── ui/           # UI components
+├── presentation/ # ViewModels
+├── domain/       # Business logic
+├── data/         # Repositories
+└── core/         # Utilities
+```
+
+
+## Common Tasks
+
+### Adding a New Screen
+
+1. Create screen component
+2. Create ViewModel
+3. Add navigation route
+4. Add tests
+5. Update wiki if feature-related
+
+
+## Troubleshooting
+
+### Build Issues
+
+1. Check error message
+2. Clean build
+3. Invalidate caches
+4. Check dependencies
+
+
+**Last Updated:** [date]

--- a/docs/templates/changelog.template.md
+++ b/docs/templates/changelog.template.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format based on [Keep a Changelog](https://keepachangelog.com/).
+
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+
+## [1.0.0] - YYYY-MM-DD
+
+### Added
+- Initial release
+
+
+---
+
+**Types of changes:**
+- `Added` - New features
+- `Changed` - Changes in existing functionality
+- `Deprecated` - Soon-to-be removed features
+- `Removed` - Removed features
+- `Fixed` - Bug fixes
+- `Security` - Vulnerability fixes
+
+**After release:** Copy to GitHub Releases.


### PR DESCRIPTION
## Summary

Add two starter templates to help new projects get started quickly.

## New Files

| Template | Purpose |
|----------|---------|
|  | Standard structure for platform dev guides |
|  | Keep a Changelog format |

## Template Structure

**PLATFORM-DEVELOPMENT.template.md:**
- Tech Stack
- Architecture
- Build Commands
- Code Patterns
- File Organization
- Common Tasks
- Troubleshooting

**changelog.template.md:**
- Keep a Changelog format
- Unreleased section
- Version sections with Added/Changed/Fixed/Removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)