### PR TITLE
Harden update-aidocs and dedup the minimalism test

### DIFF
--- a/.claude/skills/update-aidocs/SKILL.md
+++ b/.claude/skills/update-aidocs/SKILL.md
@@ -53,6 +53,7 @@ Every shipped file classifies into exactly one of:
    | `docs/subagents/index.md` | becomes the filled `docs/skills-and-agents.md` (project-owned registry; links point into `.claude/`) |
    | `docs/subagents/README.md` | replaced by `docs/CREATING_AGENTS.md` |
    | root `CODEX.md` | superseded by root `AGENTS.md` (agents.md spec — read natively by Codex, Cursor and others) |
+   | `docs/tools/jobs.md` without trigger classes (pre-2026-08 format) | rebuild in the trigger-class format from `docs/tools/jobs.template.md` (per-change / cycle-end column, Cycle-End Binding), preserving the project's own jobs — confirm with user. Not a mere drift notice: `/maintain` cannot dispatch without this format |
 
 5. **Compute the delta** — `git diff --name-status <old>..<new>` in the clone. Classify each path by the ownership contract.
 
@@ -64,7 +65,9 @@ Every shipped file classifies into exactly one of:
 
 7. **Notify on template drift** — when a `*.template.md` changed upstream and the project has a filled copy, don't touch the copy; report the template's upstream old→new diff (from the clone — the template is not present in the project) so the user can port relevant changes manually.
 
-8. **Stamp and report** — write the new commit to `docs/.aidocs-version`, then summarize: updated / added / deleted / skipped (project-owned) / conflicts / template-drift notices. Recommend `/validate-docs`.
+8. **Verify** — run `python docs/tools/check-docs.py`; fix errors the update introduced before proceeding.
+
+9. **Stamp and report** — write the new commit to `docs/.aidocs-version`, then summarize: updated / added / deleted / skipped (project-owned) / conflicts / template-drift notices. Recommend `/maintain full` — it surfaces the judgment-level drift (stale filled copies, unported template changes) that the update deliberately cannot touch.
 
 ## Rules
 

--- a/docs/DOCUMENTATION_GUIDELINES.md
+++ b/docs/DOCUMENTATION_GUIDELINES.md
@@ -6,21 +6,7 @@
 
 ## Information Minimalism
 
-### The Test
-
-Before adding documentation, ask in order:
-
-1. **Would a skilled developer need this to reconstruct or port the feature?**
-    - NO → Don't document
-    - YES → Continue
-
-2. **Is it obvious from code, naming, or structure?**
-    - YES → Don't document
-    - NO → Continue
-
-3. **Does it duplicate existing content?**
-    - YES → Reference instead
-    - NO → Document it ✅
+Before adding documentation, run the 3-question test — *needed? obvious from code? duplicate?* — defined once in [INFORMATION_MINIMALISM.md](INFORMATION_MINIMALISM.md). Fail any question → don't write it.
 
 ### What to Document
 


### PR DESCRIPTION
## Summary
Three fixes from the first real `/maintain full` run on a consuming project (IntervalTrainer):
- **Migration map row**: a pre-2026-08 `jobs.md` (no trigger classes) is rebuilt from the template, preserving project jobs — `/maintain` functionally depends on the format, so this is a migration, not a drift notice
- **Post-update Verify step**: run `check-docs.py`, then recommend `/maintain full` instead of `/validate-docs` — catches judgment-level drift immediately after an update
- **Minimalism-test dedup**: `DOCUMENTATION_GUIDELINES.md` now references `INFORMATION_MINIMALISM.md` instead of restating the 3-question test (`validation-docs` itself flags this duplication)

## Testing
- `check-docs.py`: 0 errors
- `markdownlint-cli2`: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)