### PR TITLE
fix: mermaid legend uses strokes, not fills, so labels survive dark mode

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -66,10 +66,13 @@ flowchart TD
     SIT -->|"Running a job"| JOBS["tools/jobs.md"]
     SIT -->|"Unsure"| USER(["Ask the user"])
 
-    classDef always fill:#c8e6c9,stroke:#4caf50,color:#1b5e20
-    classDef optional fill:#fff9c4,stroke:#fbc02d,color:#f57f17
-    classDef conditional fill:#bbdefb,stroke:#1976d2,color:#0d47a1
-    classDef decision fill:#fff,stroke:#616161,color:#212121
+    %% Stroke only - never fill/color. A hardcoded fill is a light-mode
+    %% assumption: the renderer's dark theme still supplies a light label
+    %% color, and the label washes out. Strokes read in both themes.
+    classDef always stroke:#2e7d32,stroke-width:3px
+    classDef optional stroke:#f9a825,stroke-width:3px,stroke-dasharray:5 3
+    classDef conditional stroke:#1565c0,stroke-width:3px
+    classDef decision stroke:#616161,stroke-width:2px
 
     class M1,M2,M3,M4 always
     class M5 optional
@@ -77,7 +80,7 @@ flowchart TD
     class SIT decision
 ```
 
-Green = always read | Yellow = read if exists | Blue = read when situation occurs
+Green outline = always read | Yellow dashed = read if exists | Blue outline = read when situation occurs
 
 
 ## Skills and Sub-Agents

--- a/docs/DOCUMENTATION_GUIDELINES.md
+++ b/docs/DOCUMENTATION_GUIDELINES.md
@@ -174,6 +174,13 @@ If someone reads only "What It Does" and "Why It Matters", they have everything 
 
 Use [Mermaid](https://mermaid.js.org/) fenced code blocks — GitHub renders these natively in repo markdown and wiki pages. Apply Information Minimalism: only add diagrams that pass the 3-question test.
 
+**Colour: strokes, never fills.** Readers render markdown in both light and dark themes. A
+`classDef ... fill:#c8e6c9,color:#1b5e20` is a light-mode assumption — the fill is applied, but
+the renderer's dark theme supplies its own label colour and wins on specificity, so the text
+washes out to near-invisible. Set `stroke`, `stroke-width` and `stroke-dasharray` and leave
+`fill` and `color` alone; the theme then always supplies a contrasting label. The reading-order
+diagram in [AGENTS.md](AGENTS.md) is the worked example.
+
 **Good fit:** state machines, multi-component interactions, data flow across layers, DB schema.
 
 | Mermaid type | Use for |


### PR DESCRIPTION
## Problem

The reading-order diagram in `docs/AGENTS.md` is close to unreadable in a dark theme:

```
classDef always fill:#c8e6c9,stroke:#4caf50,color:#1b5e20
```

The **fill** is applied. The **`color:`** is not — a dark renderer theme carries its own
`.nodeLabel` rule that wins on specificity. So the node ends up a light-mode pastel fill carrying
dark-mode light text. The `decision` node is the worst case: `fill:#fff` with near-white text.

The other diagram in `DOCUMENTATION_GUIDELINES.md` never had the problem, because it sets **no
colours at all** and lets the theme supply contrast. That contrast is the whole diagnosis.

## Fix

Encode the legend in **strokes**, not fills — no `fill`, no `color`:

```
classDef always      stroke:#2e7d32,stroke-width:3px
classDef optional    stroke:#f9a825,stroke-width:3px,stroke-dasharray:5 3
classDef conditional stroke:#1565c0,stroke-width:3px
classDef decision    stroke:#616161,stroke-width:2px
```

Every renderer then supplies its own contrasting label text in whichever theme the reader is
using. The green/yellow/blue coding survives as outlines, and "read if exists" now also reads as a
dashed border rather than relying on colour alone.

Chosen over `htmlLabels: false` or an `%%{init}%%` theme block: both work, but both pin the
diagram to assumptions about the renderer, and this file ships to consuming repos whose readers
use GitHub, IDE previews and Obsidian.

Also records the rule in `DOCUMENTATION_GUIDELINES.md`'s Diagrams section so the next diagram does
not reintroduce it. Grepped the repo — no other hardcoded diagram colours exist.

## Standard-change checklist

**Does not apply.** No doc, template, skill or agent is added, renamed or retired — this is
content only, and the file set is unchanged.

## Propagation

`docs/AGENTS.md` is upstream-owned. The five consuming repos migrated in #44 are stamped at
`7f87d51` with unmodified copies, so `/update-aidocs` applies this silently, with no conflicts and
no template-drift notices.

## Verification

- `python docs/tools/check-docs.py` → 0 errors
- `npx markdownlint-cli2` on both touched files → 0 issues

Reported by the repo owner from a dark-theme render; screenshot showed the washed-out labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
